### PR TITLE
add ExpiringCachedPropertyMixIn

### DIFF
--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -1,4 +1,3 @@
-import datetime
 import random
 from decimal import Decimal
 from functools import cached_property

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 from decimal import Decimal
 from functools import cached_property
 from typing import Optional, List
@@ -6,12 +7,14 @@ from typing import Optional, List
 from . import enums
 from .commons.caching_utils import ExpiringCachedPropertyMixin
 
+DEFAULT_LIFETIME = 5
+
 
 class System:
     def __init__(self, name: str):
         self.name = name
 
-    def __str__(self):
+    def __repr__(self):
         return f"System '{self.name}'"
 
 
@@ -19,13 +22,19 @@ class Faction:
     def __init__(self, name: str):
         self.name = name
 
-    def __str__(self):
+    def __repr__(self):
         return f"Faction '{self.name}'"
 
 
 class FactionBranch(ExpiringCachedPropertyMixin):
     # TODO: this should be handled automatically by decorator and metaclass, but not today.
-    expiring_properties_registry = {"color": 5}
+    expiring_properties_registry = {
+        "faction": DEFAULT_LIFETIME,
+        "system": DEFAULT_LIFETIME,
+        "is_main": DEFAULT_LIFETIME,
+        "influence": DEFAULT_LIFETIME,
+        "stations": DEFAULT_LIFETIME,
+    }
 
     def __init__(
         self,
@@ -34,22 +43,37 @@ class FactionBranch(ExpiringCachedPropertyMixin):
         is_main: bool = False,
         influence: Decimal = 0,
         stations: List["OrbitalStation"] = None,
-        color="blue",
     ):
         self.faction = faction
         self.system = system
         self.is_main = is_main
         self.influence = influence
         self.stations = stations or []
-        self.color = "blue"
 
-    def __str__(self):
+    def __repr__(self):
         return f"{self.faction} in {self.system}"
 
     @cached_property
-    def color(self):
-        # TODO: wip property, delete it
-        return str(datetime.datetime.now())
+    def faction(self) -> Faction:
+        raise NotImplemented
+
+    @cached_property
+    def system(self) -> System:
+        return System(
+            name=f"Dummy System {random.randint(0,1000)}"
+        )  # TODO: to be replaced
+
+    @cached_property
+    def is_main(self) -> bool:
+        raise NotImplemented
+
+    @cached_property
+    def influence(self) -> Decimal:
+        raise NotImplemented
+
+    @cached_property
+    def stations(self) -> List["OrbitalStation"]:
+        raise NotImplemented
 
 
 class OrbitalStation:
@@ -71,5 +95,5 @@ class OrbitalStation:
         self.services = services or []
         self.controlling_faction = controlling_faction
 
-    def __str__(self):
+    def __repr__(self):
         return f"{self.station_type.title()} '{self.name}'"

--- a/src/edclasses/commons/caching_utils.py
+++ b/src/edclasses/commons/caching_utils.py
@@ -1,0 +1,49 @@
+import datetime
+from functools import cached_property
+_NOT_FOUND = object()
+
+
+class cached_property_ttl(cached_property):
+    def _get_expiration_key(self):
+        return f"{self.attrname}_expiration_time"
+
+    def _get_new_expiration_time(self):
+        return datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        if self.attrname is None:
+            raise TypeError(
+                "Cannot use cached_property instance without calling __set_name__ on it.")
+        try:
+            cache = instance.__dict__
+        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {self.attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        expiration_key = self._get_expiration_key()
+        expiration_time = cache.get(expiration_key)
+        if expiration_time and datetime.datetime.utcnow() >= expiration_time:
+            cache.pop(self.attrname)
+            val = _NOT_FOUND
+        else:
+            val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            with self.lock:
+                # check if another thread filled cache while we awaited lock
+                val = cache.get(self.attrname, _NOT_FOUND)
+                if val is _NOT_FOUND:
+                    val = self.func(instance)
+                    try:
+                        cache[self.attrname] = val
+                        cache[expiration_key] = self._get_new_expiration_time()
+                    except TypeError:
+                        msg = (
+                            f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                            f"does not support item assignment for caching {self.attrname!r} property."
+                        )
+                        raise TypeError(msg) from None
+        return val

--- a/src/edclasses/commons/caching_utils.py
+++ b/src/edclasses/commons/caching_utils.py
@@ -22,13 +22,16 @@ class ExpiringCachedPropertyMixin:
     If you set None as lifetime_in_seconds, it will never expire.
     You can use self.clear_property(property_name) to manually clear the cache on given attribute
     """
+
     def _clear_property(self, item: str) -> None:
         get_attr = super().__getattribute__
         try:
             registry = get_attr("expiring_properties_registry")
         except AttributeError:
-            raise NotImplemented(f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
-                                 " ExpiringCachedPropertyMixIn")
+            raise NotImplemented(
+                f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
+                " ExpiringCachedPropertyMixIn"
+            )
         if item not in registry:
             raise ValueError(f"{self.__class__.__name__}.{item} is registered!")
 
@@ -41,10 +44,12 @@ class ExpiringCachedPropertyMixin:
     def _get_expiration_key(item: str) -> str:
         return f"{item}_expiration_time"
 
-    def _get_new_expiration_time(self, lifetime_in_seconds: int) -> Optional[datetime.datetime]:
+    def _get_new_expiration_time(
+        self, lifetime_in_seconds: int
+    ) -> Optional[datetime.datetime]:
         if lifetime_in_seconds:
             return datetime.datetime.utcnow() + datetime.timedelta(
-                seconds=lifetime_in_seconds # TODO: change to minutes
+                seconds=lifetime_in_seconds  # TODO: change to minutes
             )
         else:
             return None
@@ -60,8 +65,10 @@ class ExpiringCachedPropertyMixin:
         try:
             registry = get_attr("expiring_properties_registry")
         except AttributeError:
-            raise NotImplemented(f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
-                                 " ExpiringCachedPropertyMixIn")
+            raise NotImplemented(
+                f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
+                " ExpiringCachedPropertyMixIn"
+            )
 
         try:
             item_lifetime = registry[item]
@@ -89,8 +96,10 @@ class ExpiringCachedPropertyMixin:
         try:
             registry = get_attr("expiring_properties_registry")
         except AttributeError:
-            raise NotImplemented(f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
-                                 " ExpiringCachedPropertyMixIn")
+            raise NotImplemented(
+                f"You must define expiring_properties_registry on {self.__class__.__name__} to use"
+                " ExpiringCachedPropertyMixIn"
+            )
 
         __dict__ = get_attr("__dict__")
         if key in registry:

--- a/src/edclasses/commons/caching_utils.py
+++ b/src/edclasses/commons/caching_utils.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional, Any
 
 _NEVER_EXPIRE = 0  # TODO: this could be obj()
 
@@ -21,7 +22,7 @@ class ExpiringCachedPropertyMixin:
     If you set None as lifetime_in_seconds, it will never expire.
     You can use self.clear_property(property_name) to manually clear the cache on given attribute
     """
-    def _clear_property(self, item):
+    def _clear_property(self, item: str) -> None:
         get_attr = super().__getattribute__
         try:
             registry = get_attr("expiring_properties_registry")
@@ -37,10 +38,10 @@ class ExpiringCachedPropertyMixin:
         cache.pop(expire_key, None)
 
     @staticmethod
-    def _get_expiration_key(item):
+    def _get_expiration_key(item: str) -> str:
         return f"{item}_expiration_time"
 
-    def _get_new_expiration_time(self, lifetime_in_seconds):
+    def _get_new_expiration_time(self, lifetime_in_seconds: int) -> Optional[datetime.datetime]:
         if lifetime_in_seconds:
             return datetime.datetime.utcnow() + datetime.timedelta(
                 seconds=lifetime_in_seconds # TODO: change to minutes
@@ -49,12 +50,12 @@ class ExpiringCachedPropertyMixin:
             return None
 
     @staticmethod
-    def _is_expired(expiration_time):
+    def _is_expired(expiration_time: [datetime.datetime, int]) -> bool:
         if expiration_time and datetime.datetime.utcnow() >= expiration_time:
             return True
         return False
 
-    def __getattribute__(self, item):
+    def __getattribute__(self, item: str) -> Any:
         get_attr = super().__getattribute__
         try:
             registry = get_attr("expiring_properties_registry")
@@ -82,7 +83,7 @@ class ExpiringCachedPropertyMixin:
             )
         return val
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key: str, value: Any) -> None:
         get_attr = super().__getattribute__
 
         try:


### PR DESCRIPTION
Modification on top of functools.cached_property, allowing creation of lazy attributes on ed classes. Needed to make it possible to flawlessly operate on objects without worrying about querying the API.