### PR TITLE
Relation manager and Links between edclasses

### DIFF
--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Optional, List
+from typing import Optional, List, Set
 
 import edclasses.api_adapters.elite_bgs_adapter as bgs_adapter
 from . import enums
@@ -8,6 +8,7 @@ from .utils import UniqueInstanceMixin
 
 class System(UniqueInstanceMixin):
     keys = ("name",)
+    registry = {}
 
     def __init__(self, name: str):
         self.name = name
@@ -18,9 +19,32 @@ class System(UniqueInstanceMixin):
     def __repr__(self):
         return f"System '{self.name}'"
 
+    def add_faction_branch(self, faction: "Faction") -> "FactionBranch":
+        faction_branch = FactionBranch.create(system=self, faction=faction)
+        self._faction_branches.add(faction_branch)
+        faction._faction_branches.add(faction_branch)
+        return faction_branch
+
+    def add_station(self, **kwargs) -> "OrbitalStation":
+        station = OrbitalStation.create(system=self, **kwargs)
+        self._stations.add(station)
+        return station
+        # controlling_faction_branch = kwargs.get("controlling_faction")
+        # if controlling_faction_branch is not None:
+        #     controlling_faction_branch._stations.add(station)
+
+    @property
+    def stations(self) -> Set["OrbitalStation"]:
+        return self._stations
+
+    @property
+    def faction_branches(self) -> Set["FactionBranch"]:
+        return self._faction_branches
+
 
 class Faction(UniqueInstanceMixin):
     keys = ("name",)
+    registry = {}
 
     def __init__(self, name: str):
         self.name = name
@@ -30,12 +54,17 @@ class Faction(UniqueInstanceMixin):
     def __repr__(self):
         return f"Faction '{self.name}'"
 
+    @property
+    def faction_branches(self) -> Set["FactionBranch"]:
+        return self._faction_branches
+
 
 class FactionBranch(UniqueInstanceMixin):
     keys = (
         "faction",
         "system",
     )
+    registry = {}
     adapter = bgs_adapter.EliteBgsFactionBranchAdapter()
 
     def __init__(
@@ -55,12 +84,33 @@ class FactionBranch(UniqueInstanceMixin):
     def __repr__(self):
         return f"{self._faction} in {self._system}"
 
+    def delete(self):
+        try:
+            self._faction._faction_branches.remove(self)
+            self._system._faction_branches.remove(self)
+            del self
+        except KeyError:
+            super().delete()
+
+    @property
+    def faction(self) -> Faction:
+        return self._faction
+
+    @property
+    def system(self) -> System:
+        return self._system
+
+    @property
+    def stations(self) -> Set["OrbitalStation"]:
+        return self._stations
+
 
 class OrbitalStation(UniqueInstanceMixin):
     keys = (
         "name",
         "system",
     )
+    registry = {}
 
     def __init__(
         self,
@@ -72,7 +122,7 @@ class OrbitalStation(UniqueInstanceMixin):
     ):
         self.name = name
         self.station_type = station_type.value
-        self.system = system
+        self._system = system
         self.distance_to_arrival = distance_to_arrival
         self.services = services or []
         self._controlling_faction = None
@@ -80,3 +130,22 @@ class OrbitalStation(UniqueInstanceMixin):
 
     def __repr__(self):
         return f"{self.station_type.title()} '{self.name}'"
+
+    @property
+    def controlling_faction(self) -> FactionBranch:
+        return self._controlling_faction
+
+    @controlling_faction.setter
+    def controlling_faction(self, faction_branch: FactionBranch):
+        if faction_branch is self._controlling_faction:
+            return
+
+        if self._controlling_faction and self._controlling_faction is not faction_branch:
+            self._controlling_faction._stations.remove(self)
+            if faction_branch is not None:
+                faction_branch._stations.add(self)
+        self._controlling_faction = faction_branch
+
+    @property
+    def system(self) -> System:
+        return self._system

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -83,7 +83,7 @@ class FactionBranch(UniqueInstanceMixin):
         parent_class_name="Faction", child_class_name="FactionBranch"
     )
     _stations_relation = OneToManyRelation.create(
-        parent_class_name="System", child_class_name="OrbitalStation"
+        parent_class_name="FactionBranch", child_class_name="OrbitalStation"
     )
 
     def __init__(

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -1,13 +1,8 @@
 from decimal import Decimal
-from functools import cached_property
 from typing import Optional, List
 
 import edclasses.api_adapters.elite_bgs_adapter as bgs_adapter
 from . import enums
-
-from .commons import caching_utils as caching
-
-DEFAULT_LIFETIME = 5
 
 
 class System:
@@ -26,21 +21,16 @@ class Faction:
         return f"Faction '{self.name}'"
 
 
-class FactionBranch(caching.ExpiringCachedPropertyMixin):
+class FactionBranch:
     adapter = bgs_adapter.EliteBgsFactionBranchAdapter()
-    # TODO: this should be handled automatically by decorator and metaclass, but not today.
-    expiring_properties_registry = {
-        "influence": DEFAULT_LIFETIME,
-        "stations": DEFAULT_LIFETIME,
-    }
 
     def __init__(
         self,
         faction: Faction,
         system: System,
         is_main: bool = False,
-        influence: Decimal = caching.NOT_SET,
-        stations: List["OrbitalStation"] = caching.NOT_SET,
+        influence: Decimal = None,
+        stations: List["OrbitalStation"] = None,
     ):
         self.faction = faction
         self.system = system
@@ -51,14 +41,6 @@ class FactionBranch(caching.ExpiringCachedPropertyMixin):
     def __repr__(self):
         return f"{self.faction} in {self.system}"
 
-    @cached_property
-    def influence(self) -> Decimal:
-        return self.adapter.influence(self)
-
-    @cached_property
-    def stations(self) -> List["OrbitalStation"]:
-        return self.adapter.stations(self)
-
 
 class OrbitalStation:
     def __init__(
@@ -67,10 +49,10 @@ class OrbitalStation:
         station_type: enums.StationType,
         system: System,
         distance_to_arrival: int,
-        services: Optional[List] = caching.NOT_SET,
+        services: Optional[List] = None,
         controlling_faction: Optional[
             FactionBranch  # TODO: would it be better to use Faction instead of FactionBranch?
-        ] = caching.NOT_SET,
+        ] = None,
     ):
         self.name = name
         self.station_type = station_type.value

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -3,29 +3,29 @@ from typing import Optional, List, Set
 
 import edclasses.api_adapters.elite_bgs_adapter as bgs_adapter
 from . import enums
-from .utils import UniqueInstanceMixin, OneToOneRelation
+from .utils import UniqueInstanceMixin, OneToOneRelation, OneToManyRelation
 
 
 class System(UniqueInstanceMixin):
     keys = ("name",)
     registry = {}
-    _station_relation = OneToOneRelation.create(parent_class_name="System", child_class_name="OrbitalStation")
+    _stations_relation = OneToManyRelation.create(parent_class_name="System", child_class_name="OrbitalStation")
 
-    def __init__(self, name: str, station=None):
+    def __init__(self, name: str, stations=None):
         self.name = name
-        self.station = station
+        self.stations = stations or []
         super().__init__()
 
     def __repr__(self):
         return f"System '{self.name}'"
 
-    def _station_setter(self, value):
-        self._station_relation.set_for_parent(self, value)
+    def _stations_setter(self, value):
+        self._stations_relation.set_for_parent(self, value)
 
-    def _station_getter(self):
-        return self._station_relation.get_for_parent(self)
+    def _stations_getter(self):
+        return self._stations_relation.get_for_parent(self)
 
-    station = property(fget=_station_getter, fset=_station_setter)
+    stations = property(fget=_stations_getter, fset=_stations_setter)
 
 class Faction(UniqueInstanceMixin):
     keys = ("name",)
@@ -96,7 +96,7 @@ class OrbitalStation(UniqueInstanceMixin):
         "system",
     )
     registry = {}
-    _system_relation = OneToOneRelation.create(parent_class_name="System", child_class_name="OrbitalStation")
+    _system_relation = OneToManyRelation.create(parent_class_name="System", child_class_name="OrbitalStation")
 
     def __init__(
         self,

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -45,15 +45,19 @@ class System(UniqueInstanceMixin):
         return f"System '{self.name}'"
 
 
-class Faction:
+class Faction(UniqueInstanceMixin):
+    keys = ("name",)
+
     def __init__(self, name: str):
         self.name = name
+        super().__init__()
 
     def __repr__(self):
         return f"Faction '{self.name}'"
 
 
-class FactionBranch:
+class FactionBranch(UniqueInstanceMixin):
+    keys = ("faction", "system",)
     adapter = bgs_adapter.EliteBgsFactionBranchAdapter()
 
     def __init__(
@@ -69,12 +73,15 @@ class FactionBranch:
         self.is_main = is_main
         self.influence = influence
         self.stations = stations or []
+        super().__init__()
 
     def __repr__(self):
         return f"{self.faction} in {self.system}"
 
 
-class OrbitalStation:
+class OrbitalStation(UniqueInstanceMixin):
+    keys = ("name", "system",)
+
     def __init__(
         self,
         name: str,
@@ -92,6 +99,7 @@ class OrbitalStation:
         self.distance_to_arrival = distance_to_arrival
         self.services = services or []
         self.controlling_faction = controlling_faction
+        super().__init__()
 
     def __repr__(self):
         return f"{self.station_type.title()} '{self.name}'"

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -92,11 +92,13 @@ class FactionBranch(UniqueInstanceMixin):
         system: System,
         is_main: bool = False,
         influence: Decimal = None,
+        stations: List = None,
     ):
         self.faction = faction
         self.system = system
         self.is_main = is_main
         self.influence = influence
+        self.stations = stations or []
         super().__init__()
 
     def __repr__(self):

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -3,35 +3,7 @@ from typing import Optional, List
 
 import edclasses.api_adapters.elite_bgs_adapter as bgs_adapter
 from . import enums
-
-
-class UniqueInstanceMixin:
-    registry = {}
-    keys = tuple()
-
-    @classmethod
-    def create(cls, **kwargs):
-        try:
-            return cls(**kwargs)
-        except ValueError:
-            return cls.get_from_registry(**kwargs)
-
-    @classmethod
-    def _get_key(cls, *args, **kwargs):
-        return tuple(kwargs[attr] for attr in cls.keys)
-
-    @classmethod
-    def get_from_registry(cls, **kwargs):
-        obj_key = cls._get_key(**kwargs)
-        return cls.registry.get(obj_key)
-
-    def __init__(self, *args, **kwargs):
-        obj_key = self._get_key(**self.__dict__)
-        obj = self.__class__.registry.get(obj_key)
-        if obj is not None:
-            raise ValueError
-        self.__class__.registry[obj_key] = self
-        super().__init__()
+from .utils import UniqueInstanceMixin
 
 
 class System(UniqueInstanceMixin):
@@ -60,7 +32,10 @@ class Faction(UniqueInstanceMixin):
 
 
 class FactionBranch(UniqueInstanceMixin):
-    keys = ("faction", "system",)
+    keys = (
+        "faction",
+        "system",
+    )
     adapter = bgs_adapter.EliteBgsFactionBranchAdapter()
 
     def __init__(
@@ -82,7 +57,10 @@ class FactionBranch(UniqueInstanceMixin):
 
 
 class OrbitalStation(UniqueInstanceMixin):
-    keys = ("name", "system",)
+    keys = (
+        "name",
+        "system",
+    )
 
     def __init__(
         self,

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -39,6 +39,8 @@ class System(UniqueInstanceMixin):
 
     def __init__(self, name: str):
         self.name = name
+        self._stations = set()
+        self._faction_branches = set()
         super().__init__()
 
     def __repr__(self):
@@ -50,6 +52,7 @@ class Faction(UniqueInstanceMixin):
 
     def __init__(self, name: str):
         self.name = name
+        self._faction_branches = set()
         super().__init__()
 
     def __repr__(self):
@@ -66,17 +69,16 @@ class FactionBranch(UniqueInstanceMixin):
         system: System,
         is_main: bool = False,
         influence: Decimal = None,
-        stations: List["OrbitalStation"] = None,
     ):
-        self.faction = faction
-        self.system = system
+        self._faction = faction
+        self._system = system
         self.is_main = is_main
         self.influence = influence
-        self.stations = stations or []
+        self._stations = set()
         super().__init__()
 
     def __repr__(self):
-        return f"{self.faction} in {self.system}"
+        return f"{self._faction} in {self._system}"
 
 
 class OrbitalStation(UniqueInstanceMixin):
@@ -89,16 +91,13 @@ class OrbitalStation(UniqueInstanceMixin):
         system: System,
         distance_to_arrival: int,
         services: Optional[List] = None,
-        controlling_faction: Optional[
-            FactionBranch  # TODO: would it be better to use Faction instead of FactionBranch?
-        ] = None,
     ):
         self.name = name
         self.station_type = station_type.value
         self.system = system
         self.distance_to_arrival = distance_to_arrival
         self.services = services or []
-        self.controlling_faction = controlling_faction
+        self._controlling_faction = None
         super().__init__()
 
     def __repr__(self):

--- a/src/edclasses/classes.py
+++ b/src/edclasses/classes.py
@@ -5,9 +5,41 @@ import edclasses.api_adapters.elite_bgs_adapter as bgs_adapter
 from . import enums
 
 
-class System:
+class UniqueInstanceMixin:
+    registry = {}
+    keys = tuple()
+
+    @classmethod
+    def create(cls, **kwargs):
+        try:
+            return cls(**kwargs)
+        except ValueError:
+            return cls.get_from_registry(**kwargs)
+
+    @classmethod
+    def _get_key(cls, *args, **kwargs):
+        return tuple(kwargs[attr] for attr in cls.keys)
+
+    @classmethod
+    def get_from_registry(cls, **kwargs):
+        obj_key = cls._get_key(**kwargs)
+        return cls.registry.get(obj_key)
+
+    def __init__(self, *args, **kwargs):
+        obj_key = self._get_key(**self.__dict__)
+        obj = self.__class__.registry.get(obj_key)
+        if obj is not None:
+            raise ValueError
+        self.__class__.registry[obj_key] = self
+        super().__init__()
+
+
+class System(UniqueInstanceMixin):
+    keys = ("name",)
+
     def __init__(self, name: str):
         self.name = name
+        super().__init__()
 
     def __repr__(self):
         return f"System '{self.name}'"

--- a/src/edclasses/tests/factories/classes_factories.py
+++ b/src/edclasses/tests/factories/classes_factories.py
@@ -24,6 +24,7 @@ class FactionBranchFactory(factory.Factory):
 
     faction = factory.SubFactory(FactionFactory)
     system = factory.SubFactory(SystemFactory)
+    stations = list()
     is_main = False  # we don't need to know faction's main branch - usually we won't have this information
     influence = 50
 

--- a/src/edclasses/tests/factories/classes_factories.py
+++ b/src/edclasses/tests/factories/classes_factories.py
@@ -26,7 +26,6 @@ class FactionBranchFactory(factory.Factory):
     system = factory.SubFactory(SystemFactory)
     is_main = False  # we don't need to know faction's main branch - usually we won't have this information
     influence = 50
-    stations = set()
 
 
 class OrbitalStationFactory(factory.Factory):

--- a/src/edclasses/tests/factories/classes_factories.py
+++ b/src/edclasses/tests/factories/classes_factories.py
@@ -26,7 +26,7 @@ class FactionBranchFactory(factory.Factory):
     system = factory.SubFactory(SystemFactory)
     is_main = False  # we don't need to know faction's main branch - usually we won't have this information
     influence = 50
-    stations = list()
+    stations = set()
 
 
 class OrbitalStationFactory(factory.Factory):

--- a/src/edclasses/tests/factories/classes_factories.py
+++ b/src/edclasses/tests/factories/classes_factories.py
@@ -8,14 +8,14 @@ class SystemFactory(factory.Factory):
     class Meta:
         model = System
 
-    name = "System"
+    name = factory.Sequence(lambda n: f"System {n}")
 
 
 class FactionFactory(factory.Factory):
     class Meta:
         model = Faction
 
-    name = "Faction"
+    name = factory.Sequence(lambda n: f"Faction {n}")
 
 
 class FactionBranchFactory(factory.Factory):
@@ -32,8 +32,8 @@ class OrbitalStationFactory(factory.Factory):
     class Meta:
         model = OrbitalStation
 
-    name = "Orbital Station"
-    station_type = StationType.CORIOLIS
+    name = factory.Sequence(lambda n: f"Orbital Station {n}")
+    station_type = StationType.STATION
     system = factory.SubFactory(SystemFactory)
     distance_to_arrival = 100
     services = list()

--- a/src/edclasses/tests/test_classes.py
+++ b/src/edclasses/tests/test_classes.py
@@ -4,6 +4,7 @@ from .factories.classes_factories import (
     FactionBranchFactory,
     OrbitalStationFactory,
 )
+from .. import System, Faction, enums
 
 
 def test_system_factory():
@@ -18,3 +19,31 @@ def test_classes():
     faction = FactionFactory()
     faction_branch = FactionBranchFactory()
     station = OrbitalStationFactory()
+
+
+class TestSystem:
+    class TestCreateMethods:
+        def test_create_branch_updates_related_objects(self):
+            system: System = SystemFactory()
+            faction: Faction = FactionFactory()
+
+            faction_branch_1 = system.create_faction_branch(faction)
+            faction_branch_2 = system.create_faction_branch(faction)
+
+            assert faction_branch_1.system == system
+            assert faction_branch_1.faction == faction
+            assert system.faction_branches == {faction_branch_1, faction_branch_2}
+            assert faction.faction_branches == {faction_branch_1, faction_branch_2}
+
+        def test_create_station_updates_related_objects(self):
+            system: System = SystemFactory()
+            faction_branch = FactionBranchFactory(system=system)
+
+            station = system.create_station(name="station", station_type=enums.StationType.STATION, controlling_faction=faction_branch)
+
+            assert station.station_type == enums.StationType.STATION
+            assert station.system == system
+            assert station.controlling_faction == faction_branch
+            assert faction_branch.stations == {station}
+            assert system.stations == {station}
+    class StationControllingFactionSetter:

--- a/src/edclasses/tests/test_classes.py
+++ b/src/edclasses/tests/test_classes.py
@@ -4,13 +4,13 @@ from .factories.classes_factories import (
     FactionBranchFactory,
     OrbitalStationFactory,
 )
-from .. import System, Faction, enums
+from .. import System, Faction, enums, FactionBranch
 
 
 def test_system_factory():
     # TODO: remove, it's an exmaple test to check pytest and factory setup
     system = SystemFactory()
-    assert system.name == "System"
+    assert system.name == "System 0"
 
 
 def test_classes():
@@ -26,26 +26,34 @@ class TestSystem:
         def test_create_branch_updates_related_objects(self):
             system: System = SystemFactory()
             faction: Faction = FactionFactory()
+            faction2: Faction = FactionFactory()
 
-            faction_branch_1 = system.create_faction_branch(faction)
-            faction_branch_2 = system.create_faction_branch(faction)
+            faction_branch_1 = FactionBranchFactory(faction=faction, system=system)
+            faction_branch_2 = FactionBranchFactory(faction=faction2, system=system)
 
             assert faction_branch_1.system == system
             assert faction_branch_1.faction == faction
-            assert system.faction_branches == {faction_branch_1, faction_branch_2}
-            assert faction.faction_branches == {faction_branch_1, faction_branch_2}
+            assert faction_branch_2.system == system
+            assert faction_branch_2.faction == faction2
+            assert system.faction_branches == [faction_branch_1, faction_branch_2]
+            assert faction.faction_branches == [faction_branch_1]
+            assert faction2.faction_branches == [faction_branch_2]
 
         def test_create_station_updates_related_objects(self):
             system: System = SystemFactory()
             faction_branch = FactionBranchFactory(system=system)
 
-            station = system.create_station(name="station", station_type=enums.StationType.STATION, controlling_faction=faction_branch)
+            station1 = OrbitalStationFactory(station_type=enums.StationType.STATION, controlling_faction=faction_branch, system=system)
+            station2 = OrbitalStationFactory(station_type=enums.StationType.STATION, controlling_faction=faction_branch, system=system)
 
-            assert station.station_type == enums.StationType.STATION
-            assert station.system == system
-            assert station.controlling_faction == faction_branch
-            assert faction_branch.stations == {station}
-            assert system.stations == {station}
+            assert station1.station_type == enums.StationType.STATION.value
+            assert station1.system == system
+            assert station1.controlling_faction == faction_branch
+            assert station2.system == system
+            assert station2.controlling_faction == faction_branch
+            assert system.stations == [station1, station2]
+            assert faction_branch.stations == [station1, station2]
+
 
 class TestLinks:
     def test_links(self):

--- a/src/edclasses/tests/test_classes.py
+++ b/src/edclasses/tests/test_classes.py
@@ -1,67 +1,6 @@
-from .factories.classes_factories import (
-    SystemFactory,
-    FactionFactory,
-    FactionBranchFactory,
-    OrbitalStationFactory,
-)
-from .. import System, Faction, enums, FactionBranch
+from .factories.classes_factories import *
 
 
 def test_system_factory():
-    # TODO: remove, it's an exmaple test to check pytest and factory setup
     system = SystemFactory()
     assert system.name == "System 0"
-
-
-def test_classes():
-    # TODO: remove, it's an example test to check pytest and factory setup
-    system = SystemFactory()
-    faction = FactionFactory()
-    faction_branch = FactionBranchFactory()
-    station = OrbitalStationFactory()
-
-
-class TestSystem:
-    class TestCreateMethods:
-        def test_create_branch_updates_related_objects(self):
-            system: System = SystemFactory()
-            faction: Faction = FactionFactory()
-            faction2: Faction = FactionFactory()
-
-            faction_branch_1 = FactionBranchFactory(faction=faction, system=system)
-            faction_branch_2 = FactionBranchFactory(faction=faction2, system=system)
-
-            assert faction_branch_1.system == system
-            assert faction_branch_1.faction == faction
-            assert faction_branch_2.system == system
-            assert faction_branch_2.faction == faction2
-            assert system.faction_branches == [faction_branch_1, faction_branch_2]
-            assert faction.faction_branches == [faction_branch_1]
-            assert faction2.faction_branches == [faction_branch_2]
-
-        def test_create_station_updates_related_objects(self):
-            system: System = SystemFactory()
-            faction_branch = FactionBranchFactory(system=system)
-
-            station1 = OrbitalStationFactory(station_type=enums.StationType.STATION, controlling_faction=faction_branch, system=system)
-            station2 = OrbitalStationFactory(station_type=enums.StationType.STATION, controlling_faction=faction_branch, system=system)
-
-            assert station1.station_type == enums.StationType.STATION.value
-            assert station1.system == system
-            assert station1.controlling_faction == faction_branch
-            assert station2.system == system
-            assert station2.controlling_faction == faction_branch
-            assert system.stations == [station1, station2]
-            assert faction_branch.stations == [station1, station2]
-
-
-class TestLinks:
-    def test_links(self):
-        system = SystemFactory()
-        faction = FactionFactory(name="faction1")
-        faction2 = FactionFactory(name="faction2")
-        faction_branch = FactionBranchFactory(faction=faction, system=system)
-        faction_branch2 = FactionBranchFactory(faction=faction2, system=system)
-        assert system.faction_branches == [faction_branch, faction_branch2]
-        assert faction.faction_branches == [faction_branch]
-        assert faction2.faction_branches == [faction_branch2]

--- a/src/edclasses/tests/test_classes.py
+++ b/src/edclasses/tests/test_classes.py
@@ -46,4 +46,14 @@ class TestSystem:
             assert station.controlling_faction == faction_branch
             assert faction_branch.stations == {station}
             assert system.stations == {station}
-    class StationControllingFactionSetter:
+
+class TestLinks:
+    def test_links(self):
+        system = SystemFactory()
+        faction = FactionFactory(name="faction1")
+        faction2 = FactionFactory(name="faction2")
+        faction_branch = FactionBranchFactory(faction=faction, system=system)
+        faction_branch2 = FactionBranchFactory(faction=faction2, system=system)
+        assert system.faction_branches == [faction_branch, faction_branch2]
+        assert faction.faction_branches == [faction_branch]
+        assert faction2.faction_branches == [faction_branch2]

--- a/src/edclasses/tests/test_relations.py
+++ b/src/edclasses/tests/test_relations.py
@@ -1,0 +1,108 @@
+from edclasses import OneToManyRelation
+
+
+class Parent:
+    _children_relation = OneToManyRelation.create(
+        parent_class_name="Parent", child_class_name="Child"
+    )
+
+    def __init__(self, children=None):
+        self.children = children or []
+
+    def _children_setter(self, value):
+        self._children_relation.set_for_parent(self, value)
+
+    def _children_getter(self):
+        return self._children_relation.get_for_parent(self)
+
+    children = property(fget=_children_getter, fset=_children_setter)
+
+
+class Child:
+    _parent_relation = OneToManyRelation.create(
+        parent_class_name="Parent", child_class_name="Child"
+    )
+
+    def __init__(self, parent=None):
+        self.parent = parent
+
+    def _parent_setter(self, value):
+        self._parent_relation.set_for_child(self, value)
+
+    def _parent_getter(self):
+        return self._parent_relation.get_for_child(self)
+
+    parent = property(fget=_parent_getter, fset=_parent_setter)
+
+
+class TestOneToManyRelation:
+    class TestChildSide:
+        def test_removing_parent_removes_link(self):
+            parent = Parent()
+            child = Child(parent=parent)
+            assert child.parent == parent
+            assert parent.children == [child]
+
+            child.parent = None
+
+            assert child.parent is None
+            assert parent.children == []
+
+        def test_adding_parent_creates_link(self):
+            parent = Parent()
+            child = Child()
+
+            child.parent = parent
+
+            assert child.parent is parent
+            assert parent.children == [child]
+
+        def test_replacing_parent_replaces_link(self):
+            old_parent = Parent()
+            new_parent = Parent()
+            child = Child(parent=old_parent)
+            assert old_parent is not new_parent
+            assert child.parent is old_parent
+            assert old_parent.children == [child]
+
+            child.parent = new_parent
+
+            assert child.parent is new_parent
+            assert new_parent.children == [child]
+            assert old_parent.children == []
+
+    class TestParentSide:
+        def test_removing_children_removes_links(self):
+            child1 = Child()
+            child2 = Child()
+            parent = Parent(children=[child1, child2])
+            assert child1.parent is parent
+            assert child2.parent is parent
+
+            parent.children = []
+
+            assert child1.parent is None
+            assert child2.parent is None
+
+        def test_adding_children_adds_links(self):
+            child1 = Child()
+            child2 = Child()
+            parent = Parent(children=[])
+
+            parent.children = [child1, child2]
+
+            assert child1.parent is parent
+            assert child2.parent is parent
+
+        def test_stealing_children_replaces_links(self):
+            old_parent = Parent()
+            child1 = Child(parent=old_parent)
+            child2 = Child(parent=old_parent)
+            new_parent = Parent()
+            assert old_parent.children == [child1, child2]
+            new_parent.children = [child2]
+
+            assert child1.parent is old_parent
+            assert child2.parent is new_parent
+            assert new_parent.children == [child2]
+            assert old_parent.children == [child1]

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -112,7 +112,6 @@ class OneToManyRelation(OneToOneRelation):
         old_children = self.get_for_parent(parent_obj)
         for child in old_children:
             self.child_side.pop(child)
-            # self._delete_link(parent_obj, child)
 
         for child in children:
             old_parent = self.get_for_child(child)

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -55,21 +55,14 @@ class OneToOneRelation(UniqueInstanceMixin):
         self.child_side = {}
         super().__init__()
 
-    def _get_relation_key(self) -> Tuple[str, str]:
-        return self.parent_class_name, self.child_class_name
-
     def set_for_parent(self, parent_obj, child_obj):
         old_child = self.get_for_parent(parent_obj)
 
         if old_child and child_obj is not old_child:
-            self._clear_link(parent_obj, old_child)
+            self._delete_link(parent_obj, old_child)
 
         if child_obj is not None:
-            self._set_for_parent(parent_obj, child_obj)
-
-    def _set_for_parent(self, parent_obj, child_obj):
-        self.parent_side[parent_obj] = child_obj
-        self.child_side[child_obj] = parent_obj
+            self._add_link(parent_obj, child_obj)
 
     def get_for_parent(self, parent_obj):
         return self.parent_side.get(parent_obj, None)
@@ -78,18 +71,18 @@ class OneToOneRelation(UniqueInstanceMixin):
         old_parent = self.get_for_child(child_obj)
 
         if old_parent and parent_obj is not old_parent:
-            self._clear_link(old_parent, child_obj)
+            self._delete_link(old_parent, child_obj)
 
         if parent_obj is not None:
-            self._set_for_child(child_obj, parent_obj)
-
-    def _set_for_child(self, child_obj, parent_obj):
-        self.child_side[child_obj] = parent_obj
-        self.parent_side[parent_obj] = child_obj
+            self._add_link(parent_obj, child_obj)
 
     def get_for_child(self, child_obj):
         return self.child_side.get(child_obj, None)
 
-    def _clear_link(self, parent_obj, child_obj):
+    def _delete_link(self, parent_obj, child_obj):
         self.parent_side.pop(parent_obj)
         self.child_side.pop(child_obj)
+
+    def _add_link(self, parent_obj, child_obj):
+        self.parent_side[parent_obj] = child_obj
+        self.child_side[child_obj] = parent_obj

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -15,7 +15,11 @@ class UniqueInstanceMixin:
 
     @classmethod
     def _get_key(cls, *args, **kwargs):
-        return tuple(kwargs[attr] for attr in cls.keys)
+        if args:
+            instance = args[0]
+            return tuple(getattr(instance,attr) for attr in cls.keys)
+        else:
+            return tuple(kwargs[attr] for attr in cls.keys)
 
     @classmethod
     def get_from_registry(cls, **kwargs):
@@ -23,9 +27,16 @@ class UniqueInstanceMixin:
         return cls.registry.get(obj_key)
 
     def __init__(self, *args, **kwargs):
-        obj_key = self._get_key(**self.__dict__)
+        obj_key = self._get_key(self)
         obj = self.__class__.registry.get(obj_key)
         if obj is not None:
             raise ValueError
         self.__class__.registry[obj_key] = self
         super().__init__()
+
+    def remove_from_registry(self):
+        obj_key = self._get_key(**self.__dict__)
+        self.registry.pop(obj_key)
+
+    def delete(self):
+        self.remove_from_registry()

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -1,2 +1,31 @@
 def return_first_match(func, items):
     return next(item for item in items if func(item))
+
+
+class UniqueInstanceMixin:
+    registry = {}
+    keys = tuple()
+
+    @classmethod
+    def create(cls, **kwargs):
+        try:
+            return cls(**kwargs)
+        except ValueError:
+            return cls.get_from_registry(**kwargs)
+
+    @classmethod
+    def _get_key(cls, *args, **kwargs):
+        return tuple(kwargs[attr] for attr in cls.keys)
+
+    @classmethod
+    def get_from_registry(cls, **kwargs):
+        obj_key = cls._get_key(**kwargs)
+        return cls.registry.get(obj_key)
+
+    def __init__(self, *args, **kwargs):
+        obj_key = self._get_key(**self.__dict__)
+        obj = self.__class__.registry.get(obj_key)
+        if obj is not None:
+            raise ValueError
+        self.__class__.registry[obj_key] = self
+        super().__init__()

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -112,8 +112,12 @@ class OneToManyRelation(OneToOneRelation):
         old_children = self.get_for_parent(parent_obj)
         for child in old_children:
             self.child_side.pop(child)
+            # self._delete_link(parent_obj, child)
 
         for child in children:
+            old_parent = self.get_for_child(child)
+            if old_parent is not None:
+                self._delete_link(old_parent, child)
             self.child_side[child] = parent_obj
 
         self.parent_side[parent_obj] = children

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+
+
 def return_first_match(func, items):
     return next(item for item in items if func(item))
 
@@ -40,3 +43,31 @@ class UniqueInstanceMixin:
 
     def delete(self):
         self.remove_from_registry()
+
+
+class OneToOneRelation(UniqueInstanceMixin):
+    keys = ("parent_class_name", "child_class_name",)
+
+    def __init__(self, parent_class_name: str, child_class_name: str):
+        self.parent_class_name = parent_class_name
+        self.child_class_name = child_class_name
+        self.parent_side = {}
+        self.child_side = {}
+        super().__init__()
+
+    def _get_relation_key(self) -> Tuple[str, str]:
+        return self.parent_class_name, self.child_class_name
+
+    def set_for_parent(self, parent_obj, child_obj):
+        self.parent_side[parent_obj] = child_obj
+        self.child_side[child_obj] = parent_obj
+
+    def get_for_parent(self, parent_obj):
+        return self.parent_side.get(parent_obj, None)
+
+    def set_for_child(self, child_obj, parent_obj):
+        self.child_side[child_obj] = parent_obj
+        self.parent_side[parent_obj] = child_obj
+
+    def get_for_child(self, child_obj):
+        return self.child_side.get(child_obj, None)

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -59,6 +59,15 @@ class OneToOneRelation(UniqueInstanceMixin):
         return self.parent_class_name, self.child_class_name
 
     def set_for_parent(self, parent_obj, child_obj):
+        old_child = self.get_for_parent(parent_obj)
+
+        if old_child and child_obj is not old_child:
+            self._clear_link(parent_obj, old_child)
+
+        if child_obj is not None:
+            self._set_for_parent(parent_obj, child_obj)
+
+    def _set_for_parent(self, parent_obj, child_obj):
         self.parent_side[parent_obj] = child_obj
         self.child_side[child_obj] = parent_obj
 
@@ -66,8 +75,21 @@ class OneToOneRelation(UniqueInstanceMixin):
         return self.parent_side.get(parent_obj, None)
 
     def set_for_child(self, child_obj, parent_obj):
+        old_parent = self.get_for_child(child_obj)
+
+        if old_parent and parent_obj is not old_parent:
+            self._clear_link(old_parent, child_obj)
+
+        if parent_obj is not None:
+            self._set_for_child(child_obj, parent_obj)
+
+    def _set_for_child(self, child_obj, parent_obj):
         self.child_side[child_obj] = parent_obj
         self.parent_side[parent_obj] = child_obj
 
     def get_for_child(self, child_obj):
         return self.child_side.get(child_obj, None)
+
+    def _clear_link(self, parent_obj, child_obj):
+        self.parent_side.pop(parent_obj)
+        self.child_side.pop(child_obj)

--- a/src/edclasses/utils.py
+++ b/src/edclasses/utils.py
@@ -14,7 +14,7 @@ class UniqueInstanceMixin:
     def create(cls, **kwargs):
         try:
             return cls(**kwargs)
-        except ValueError:
+        except InstanceAlreadyExists:
             return cls.get_from_registry(**kwargs)
 
     @classmethod
@@ -34,7 +34,7 @@ class UniqueInstanceMixin:
         obj_key = self._get_key(self)
         obj = self.__class__.registry.get(obj_key)
         if obj is not None:
-            raise ValueError
+            raise InstanceAlreadyExists
         self.__class__.registry[obj_key] = self
         super().__init__()
 
@@ -132,3 +132,7 @@ class OneToManyRelation(OneToOneRelation):
 
         if parent_obj is not None:
             self._add_link(parent_obj, child_obj)
+
+
+class InstanceAlreadyExists(Exception):
+    pass


### PR DESCRIPTION
- temporarily revert API changes within ed classes (will be introduced when classes work properly with manually provided data)
- introduce a custom made relation manager, which makes it easy to configure one to one and one to many relations between classes
- set up relations between System, Faction, FactionBranch and OrbitalStation classes.