### PR TITLE
Request number limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==6.2.5
 pytest-factoryboy==2.1.0
+ratelimit=2.2.1

--- a/src/edclasses/api_clients.py
+++ b/src/edclasses/api_clients.py
@@ -8,14 +8,20 @@ from functools import lru_cache
 class EliteBgsClient:
     API_URL = "https://elitebgs.app/api/ebgs/v5/"
 
+    def __init__(self):
+        self.session = requests.Session()
+
+    def _get_request(self, path="", **kwargs):
+        url = parse.urljoin(self.API_URL, path)
+        print(f"Shooting at {url} with params {kwargs}")
+        response = self.session.get(url, params=kwargs)
+        return response.json()
+
     @lru_cache  # TODO: replace this with a proper cache:
     # we should have a time expiring cache, would be best if we would save single objects from API response
     # (e.g. object representing faction presence) and then reuse that.
     def get_request(self, path="", **kwargs):
-        url = parse.urljoin(self.API_URL, path)
-        print(f"Shooting at {url} with params {kwargs}")
-        response = requests.get(url, params=kwargs)
-        return response.json()
+        return self._get_request(path, **kwargs)
 
     def factions(self, **kwargs):
         return self.get_request("factions", **kwargs)

--- a/src/edclasses/api_clients.py
+++ b/src/edclasses/api_clients.py
@@ -4,6 +4,8 @@ from urllib import parse
 import requests
 from functools import lru_cache
 
+from ratelimit import limits
+
 
 class EliteBgsClient:
     API_URL = "https://elitebgs.app/api/ebgs/v5/"
@@ -11,6 +13,7 @@ class EliteBgsClient:
     def __init__(self):
         self.session = requests.Session()
 
+    @limits(calls=20, period=60)
     def _get_request(self, path="", **kwargs):
         url = parse.urljoin(self.API_URL, path)
         print(f"Shooting at {url} with params {kwargs}")


### PR DESCRIPTION
Limit the number of requests sent by EliteBgsClient to 20 per 1 minute.
After that an error is raised. It will be decided later how to handle the error, for now I just want to make sure I won't flood the API due to programming error.