### PR TITLE
Remove mocked adapter; use models without adapters instead of full classes in tests

### DIFF
--- a/src/edclasses/tests/factories/classes_factories.py
+++ b/src/edclasses/tests/factories/classes_factories.py
@@ -1,31 +1,24 @@
 import factory
 
-from ...tests.mocked_adapter import MockedAdapter
 from ...models import SystemModel, FactionModel, FactionBranchModel, OrbitalStationModel
 from ...enums import StationType
 
-MOCKED_ADAPTER = MockedAdapter()
 
-
-class EDModelFactoryBase(factory.Factory):
-    adapter = MOCKED_ADAPTER
-
-
-class SystemFactory(EDModelFactoryBase):
+class SystemFactory(factory.Factory):
     class Meta:
         model = SystemModel
 
     name = factory.Sequence(lambda n: f"System {n}")
 
 
-class FactionFactory(EDModelFactoryBase):
+class FactionFactory(factory.Factory):
     class Meta:
         model = FactionModel
 
     name = factory.Sequence(lambda n: f"Faction {n}")
 
 
-class FactionBranchFactory(EDModelFactoryBase):
+class FactionBranchFactory(factory.Factory):
     class Meta:
         model = FactionBranchModel
 
@@ -36,7 +29,7 @@ class FactionBranchFactory(EDModelFactoryBase):
     influence = 50
 
 
-class OrbitalStationFactory(EDModelFactoryBase):
+class OrbitalStationFactory(factory.Factory):
     class Meta:
         model = OrbitalStationModel
 

--- a/src/edclasses/tests/test_classes.py
+++ b/src/edclasses/tests/test_classes.py
@@ -1,9 +1,8 @@
 from .. import enums
-from ..classes import System, OrbitalStation
+from ..models import OrbitalStationModel, SystemModel, FactionBranchModel
 from ..tests.factories.classes_factories import (
     SystemFactory,
     OrbitalStationFactory,
-    MOCKED_ADAPTER,
     FactionBranchFactory,
     FactionFactory,
 )
@@ -25,8 +24,8 @@ class TestClassesRelations:
     def test_station_factory(self):
         station = OrbitalStationFactory()
 
-        assert isinstance(station.system, System)
-        assert isinstance(station.controlling_faction, FactionBranch)
+        assert isinstance(station.system, SystemModel)
+        assert isinstance(station.controlling_faction, FactionBranchModel)
         assert station.distance_to_arrival == 100
         assert station.services == []
 
@@ -39,12 +38,11 @@ class TestClassesRelations:
         assert system.stations == [station, station2]
 
     def test_create_assigns_station_to_system_correctly(self):
-        system = System.create(name="Test System", adapter=MOCKED_ADAPTER)
-        station = OrbitalStation.create(
+        system = SystemModel.create(name="Test System")
+        station = OrbitalStationModel.create(
             system=system,
             name="Super Station",
             station_type=enums.StationType.STATION,
-            adapter=MOCKED_ADAPTER,
         )
 
         assert station.system == system


### PR DESCRIPTION
After seperating full classes from objects models, and using the models in test factories, we no longer need to use MockedAdapter - without the adapter connected our objects simply retrieve the attributes.

Whole adapter mechanism will have to be tested somewhere else, but it wasn't really tested here anyway.